### PR TITLE
fix : 중복 휴대폰 번호가 있는 경우에 자신의 정보 조회 오류 수정

### DIFF
--- a/src/main/kotlin/com/api/heys/domain/user/repository/UserDetailCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/api/heys/domain/user/repository/UserDetailCustomRepositoryImpl.kt
@@ -16,8 +16,14 @@ class UserDetailCustomRepositoryImpl (
     override fun findUserDetail(userDetailSearchDto: UserDetailSearchDto): UserDetail? {
         return jpaQueryFactory.selectFrom(userDetail)
             .join(userDetail.users, users).fetchJoin()
-            .where(equalUserId(userDetailSearchDto.userId), equalUserPhone(userDetailSearchDto.phone))
+            .where(equalUserId(userDetailSearchDto.userId),
+                equalUserPhone(userDetailSearchDto.phone),
+                equalIsAvailable())
             .fetchOne()
+    }
+
+    fun equalIsAvailable() : BooleanExpression? {
+        return users.isAvailable.eq(true)
     }
 
     fun equalUserPhone(phone: String?) : BooleanExpression? {


### PR DESCRIPTION
## 정보를 조회시 휴대폰 번호가 겹치더라도 활성화된 휴대폰 번호만 들고 오도록 수정